### PR TITLE
Add artifacts capturing function

### DIFF
--- a/codescroll/_artifact_builder.py
+++ b/codescroll/_artifact_builder.py
@@ -1,0 +1,75 @@
+import json
+import shutil
+import errno
+import cslib
+
+from codescroll.runner import *
+
+
+class _ArtifactBuilder(Runner):
+    """
+    This runner gathers all available outputs (headers, source files, shared objects, etc.)
+    and zip them while preserving the file structures.
+    Temporary files are ignored, because they are deleted before building is completed.
+    """
+    def __init__(self, extra_dependency_blacklist: set = None):
+        super().__init__()
+        if type(extra_dependency_blacklist) is list:
+            extra_dependency_blacklist = set(extra_dependency_blacklist)
+        extra_dependency_blacklist = set() if not extra_dependency_blacklist else extra_dependency_blacklist
+        self._artifacts_dir_name = 'artifacts'
+        self._artifacts_zip_name = 'artifacts.zip'
+        self.dependency_blacklist = {
+            '/dev/random',
+            '/dev/urandom',
+            '/dev/arandom'
+        }
+        self.dependency_blacklist.update(extra_dependency_blacklist)
+
+    def start(self, options, compile_commands_json_path=None):
+        if os.name != 'posix':
+            raise NotImplementedError('NT system support is not implemented')
+        # FIXME: Want to get project_json, not compile_commands_json.
+        if not os.path.exists(compile_commands_json_path):
+            return False, None
+
+        project_json_path = os.path.join(libcsbuild.get_working_dir(), "project.json")
+        all_dependencies = set()
+        with open(project_json_path, "r") as project_json_file:
+            project_json = json.load(project_json_file)
+            for module in project_json['modules']:
+                for source in module['sources']:
+                    for dependency in source['dependencies']:
+                        all_dependencies.add(dependency)
+
+        artifacts_dir_path = libcsbuild.libcsbuild.get_working_dir() + os.sep + self._artifacts_dir_name
+        if os.name == 'posix':
+            artifacts_dir_path = libcsbuild.libcsbuild.get_working_dir() + os.sep + self._artifacts_dir_name
+            for dependency in all_dependencies.difference(self.dependency_blacklist):
+                if not dependency.startswith(os.sep):
+                    libcsbuild.error_message('All dependency should starts with \''+os.sep+'/\'.' +
+                                             'However, dependency path is \' ' + dependency + '\'.'
+                                             )
+                    return False, None
+                else:
+                    src = dependency
+                    if not os.path.isfile(src):
+                        continue
+                    dest = artifacts_dir_path + dependency
+                    try:
+                        shutil.copy(src, dest)
+                    except IOError as e:
+                        # ENOENT(2): file does not exist, raised also on missing dest parent dir
+                        if e.errno != errno.ENOENT:
+                            raise
+                        # try creating parent directories
+                        os.makedirs(os.path.dirname(dest))
+                        shutil.copy(src, dest)
+        else:  # not posix (e.g. nt system)
+            raise NotImplementedError('NT system support is not implemented')
+
+        # zip artifacts
+        artifacts_zip_path = os.path.join(libcsbuild.libcsbuild.get_working_dir(), self._artifacts_zip_name)
+        cslib.zip_project(artifacts_dir_path, artifacts_zip_path)
+        libcsbuild.step_message("artifacts.zip written [%s]" % artifacts_zip_path)
+        return True, artifacts_zip_path

--- a/codescroll/_clang_compilation_database.py
+++ b/codescroll/_clang_compilation_database.py
@@ -50,7 +50,7 @@ class _ClangCompilationDatabaseExport(Runner):
                 json.dump(compile_db, f, indent=4)
 
         libcsbuild.step_message("compile_commands.json written [%s]" % compile_commands_json_path)
-        return True, None
+        return True, compile_commands_json_path
 
 
 

--- a/codescroll/run.py
+++ b/codescroll/run.py
@@ -5,6 +5,7 @@ import cslib
 from codescroll._capture_common import _LinuxBuild, _LinuxStracePreprocess
 from codescroll._clang_compilation_database import _ClangCompilationDatabaseExport
 from codescroll._project_information_builder import _ProjectInformationBuilder
+from codescroll._artifact_builder import _ArtifactBuilder
 from codescroll.runner import *
 
 
@@ -17,11 +18,20 @@ def run():
         libcsbuild.error_message("%s directory is not right permission to do your request" % working_directory)
         return False, None
 
-    build_with_ctrace = _LinuxBuild() #if not cslib.is_windows() else WindowsBuild()
+    build_with_ctrace = _LinuxBuild()  # if not cslib.is_windows() else WindowsBuild()
     build_trace_processor = _LinuxStracePreprocess()
     project_json_builder = _ProjectInformationBuilder()
     compile_commands_json_export = _ClangCompilationDatabaseExport()
-    build_with_ctrace.next(build_trace_processor).next(project_json_builder).next(compile_commands_json_export)
+    artifact_builder = _ArtifactBuilder()
+
+    # FIXME: Set project_json_builder to points not only compile_commands_json_export, but artifact_builder
+    #        Maybe we should modify runner.py
+    build_with_ctrace.\
+        next(build_trace_processor).\
+        next(project_json_builder).\
+        next(compile_commands_json_export).\
+        next(artifact_builder)
+
     return build_with_ctrace.run(None)
 
 
@@ -34,5 +44,10 @@ def run_post():
     build_trace_processor = _LinuxStracePreprocess()
     project_json_builder = _ProjectInformationBuilder()
     compile_commands_json_export = _ClangCompilationDatabaseExport()
-    build_trace_processor.next(project_json_builder).next(compile_commands_json_export)
+    artifact_builder = _ArtifactBuilder()
+    build_trace_processor.\
+        next(project_json_builder).\
+        next(compile_commands_json_export).\
+        next(artifact_builder)
+
     return build_trace_processor.run(None)


### PR DESCRIPTION
Now 'capture' and 'captured' options gather all building outputs,
and write zipped artifacts at '.xdb/artifacts.zip'